### PR TITLE
Use more specific variable name for env

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Install the required packages in Debian derivatives
   apt: name={{ item }} state=installed update_cache=yes
   with_items: ntp_pkgs
-  environment: env
+  environment: apt_env
   when: ansible_os_family == 'Debian'
 
 - name: Copy the ntp.conf template file

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
-env:
+apt_env:
  RUNLEVEL: 1
 


### PR DESCRIPTION
NTP role was using a variable, `env`, defined in `ntp/vars/main.yml`. It looks like this variable was being stomped on by `env` variable in `scripts/jenkins_runplay.sh`. See [this Test_Tower_Install job](http://jenkins.testing.ansible.com/view/Tower/job/Test_Tower_Install/3753/PLATFORM=ubuntu-12.04-x86_64,label=test/console), for example:

```
+ for LINE in '$(env)'
+ IFS==
+ set -- ANSIBLE_NIGHTLY_TAR_PATH jenkins.testing.ansible.com:jenkins.testing.ansible.com:/var/www/html/ansible_nightlies_QcGXFZKv5VfQHi/tar
+ VARNAME=ANSIBLE_NIGHTLY_TAR_PATH
+ case $VARNAME in
+ echo 'ansible_nightly_tar_path: '\''jenkins.testing.ansible.com:jenkins.testing.ansible.com:/var/www/html/ansible_nightlies_QcGXFZKv5VfQHi/tar'\'''

...

TASK [ntp : Install the required packages in Debian derivatives] ***************
[DEPRECATION WARNING]: Using bare variables for environment is deprecated. 
Update your playbooks so that the environment value uses the full variable 
syntax ('{{foo}}'). This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
fatal: [ec2-54-166-117-149.compute-1.amazonaws.com]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}
```
