### PR TITLE
Updated for ansible-2.2 and fixed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ BSD
 Author Information
 ------------------
 
+James Laska
 Benno Joy
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,12 @@
 
 - name: Install the required packages in Redhat derivatives
   yum: name={{ item }} state=installed
-  with_items: ntp_pkgs
+  with_items: "{{ ntp_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 - name: Install the required packages in Debian derivatives
   apt: name={{ item }} state=installed update_cache=yes
-  with_items: ntp_pkgs
+  with_items: "{{ ntp_pkgs }}"
   environment:
     RUNLEVEL: 1
   when: ansible_os_family == 'Debian'
@@ -20,6 +20,6 @@
   notify: restart ntp
 
 # Using a handler will wait until the play completes, I'd like this to happen
-# soner to give ntpd a chance to catch up.
+# sooner to give ntpd a chance to catch up.
 - name: Ensure ntp is started and enabled
   service: name={{ ntp_svc_name }} state=started enabled=yes


### PR DESCRIPTION
:shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell:
### Description
- Removed use of bare variables to provide support for ansible-2.2.
- Miscellaneous docs updates.

New role output as follow (on a RHEL system):

```
TASK [ntp : Add the OS specific varibles] **************************************
ok: [ec2-54-160-192-109.compute-1.amazonaws.com]

TASK [ntp : Install the required packages in Redhat derivatives] ***************
changed: [ec2-54-160-192-109.compute-1.amazonaws.com] => (item=[u'libselinux-python', u'ntp'])

TASK [ntp : Install the required packages in Debian derivatives] ***************
skipping: [ec2-54-160-192-109.compute-1.amazonaws.com] => (item=[]) 

TASK [ntp : Copy the ntp.conf template file] ***********************************
changed: [ec2-54-160-192-109.compute-1.amazonaws.com]

TASK [ntp : Ensure ntp is started and enabled] *********************************
changed: [ec2-54-160-192-109.compute-1.amazonaws.com]

TASK [awx_setup : download ansible-tower-setup tarball] ************************
changed: [ec2-54-160-192-109.compute-1.amazonaws.com]
```

:shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell::shell:
